### PR TITLE
fix: scope word regex

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ const main = async (
   if (!!scopeFile || !!scope) {
     // Scope is specified in a .txt file or is passed in a string
     const content = scope ?? fs.readFileSync(scopeFile as string, { encoding: 'utf8', flag: 'r' });
-    for (const word of [...content.matchAll(/[a-zA-Z\/\.\-\_0-9]+/g)].map(r => r[0])) {
+    for (const word of [...content.matchAll(/[a-zA-Z\/\.\-\_\(\)0-9]+/g)].map(r => r[0])) {
       if (word.endsWith('.sol') && fs.existsSync(`${basePath}${word}`)) {
         fileNames.push(word);
       }


### PR DESCRIPTION
This change handles case like 'contracts/v(a)/example.sol'. Or the original code would parse this case in a wrong way. Maybe still not the perfect regex for any file path. But this change fixed file paths with parentheses.