### PR TITLE
Apply one remapping per path

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -68,20 +68,15 @@ const findImports = (basePath: string) => {
         const remappings = fs.readFileSync(path.resolve(basePath, prefix, 'remappings.txt'), 'utf8');
         for (const line of remappings.split('\n')) {
           if (!!line.split('=')[0] && !!line.split('=')[1]) {
-            relativePath = relativePath.replace(line.split('=')[0], line.split('=')[1]);
+            const remapped = relativePath.replace(line.split('=')[0], line.split('=')[1]);
+            if (remapped !== relativePath){
+              relativePath = remapped;
+              break;
+            }
+            relativePath = remapped;
           }
         }
         
-        // Dedouping logic for nested remappings
-        let arrayRelativePath = relativePath.split("/");
-        let dedoupedArrayRelativePath = [arrayRelativePath[0]];
-        for(let j = 1; j < arrayRelativePath.length; j++){
-          if(arrayRelativePath[j - 1] != arrayRelativePath[j]){
-            dedoupedArrayRelativePath.push(arrayRelativePath[j]);
-          }
-        }
-        relativePath = dedoupedArrayRelativePath.join("/");
-
         const absolutePath = path.resolve(basePath, relativePath);
         const source = fs.readFileSync(absolutePath, 'utf8');
         return { contents: source };


### PR DESCRIPTION
The previous code processed multiple remappings for a single path and then attempted to "dedup" nested remappings, whatever that means.

The "dedup" did not work at all, for example with Foundry's template Counter project, Analyzer would look for the file "lib/forge-std/src/lib/ds-test/src/test.sol" which did not exist. 

And if you allow multiple remappings on a single path, you end up with "lib/lib/forge-std/src/lib/ds-test/src/test.sol", which also does not exist.

This commit does one remapping rule per path and breaks out of the loop, which is the way remappings should work.