### PR TITLE
[Refactor Rule Description] Improve description of the `libraryPublicFunction`

### DIFF
--- a/src/issues/M/libraryPublicFunction.ts
+++ b/src/issues/M/libraryPublicFunction.ts
@@ -8,7 +8,7 @@ const issue: ASTIssue = {
   type: IssueTypes.M,
   title: 'Library function isn\'t `internal` or `private`',
   description:
-    'In a library, using an external or public visibility means that we won\'t be going through the library with a DELEGATECALL but with a CALL. This changes the context and should be done carefully.',
+    'In a library, using an external or public visibility means that the function can only be accessed via `DELEGATECALL` on chain (in case the library is deployed on chain). This changes the context and should be done carefully. For Solidity libraries with internal functions, they are not deployed on chain and are executed with a jump instruction in the contract.',
   detector: (files: InputType): Instance[] => {
     let instances: Instance[] = [];
     for (const file of files) {


### PR DESCRIPTION
The previous [description](https://github.com/code-423n4/2024-04-panoptic/blob/main/4naly3er-report.md#m-2-library-function-isnt-internal-or-private) is confusing.

```
In a library, using an external or public visibility means that we won't be going through the library with a DELEGATECALL but with a CALL. This changes the context and should be done carefully.
```

A refactor on description is made with reference to https://eip2535diamonds.substack.com/p/the-difference-between-solidity-libraries.

```
In a library, using an external or public visibility means that the function can only be accessed via `DELEGATECALL` on chain (in case the library is deployed on chain). This changes the context and should be done carefully. For Solidity libraries with internal functions, they are not deployed on chain and are executed with a jump instruction in the contract.
```